### PR TITLE
Use dockerfile for production run

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 MONGO_URI=mongodb+srv://user:pwd@host.mongodb.net/?retryWrites=true&w=majority
 JWT_SECRET=your_secret_key
-ACCESS_TOKEN_EXPIRE_HOURS = 24
+ACCESS_TOKEN_EXPIRE_HOURS=24
 S3_BUCKET_NAME=your_bucket_name
 S3_PRESIGNED_URL_EXPIRY_SECONDS=3600
 AWS_ACCESS_KEY_ID=your_access_key_id

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.9
+
+WORKDIR /code
+
+COPY ./requirements.txt /code/requirements.txt
+
+RUN pip install --no-cache-dir --upgrade -r /code/requirements.txt
+
+COPY ./app /code/app
+
+CMD ["uvicorn", "app.server:app", "--proxy-headers", "--host", "0.0.0.0", "--port", "8001"]

--- a/README.md
+++ b/README.md
@@ -31,4 +31,4 @@ make run
 
 ## API Documentation
 
-- [Swagger UI](http://hataraki-dev.hellodon.dev/docs)
+- [Swagger UI](https://hataraki-dev.hellodon.dev/docs)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ RESTful API service for Hataraki.
 ## Pre-requisite Installation
 
 - Python >= 3.9
-- GNU Make
+- GNU Make (for development)
+- Docker (for production deployment)
 
 ## Recommended tools
 
@@ -24,10 +25,10 @@ RESTful API service for Hataraki.
 # run in development mode
 make run
 
-# run in production mode
+# run in production mode (ensure docker is running)
 ./bootstrap.sh
 ```
 
 ## API Documentation
 
-- [Swagger UI](http://localhost:8001/docs)
+- [Swagger UI](http://hataraki-dev.hellodon.dev/docs)

--- a/app/config.py
+++ b/app/config.py
@@ -1,4 +1,4 @@
-from pydantic import BaseSettings, EmailStr
+from pydantic import BaseSettings, EmailStr, validator
 
 
 class Settings(BaseSettings):
@@ -48,3 +48,8 @@ class LogConfig(BaseSettings):
     loggers = {
         "hataraki-backend": {"handlers": ["default"], "level": LOG_LEVEL},
     }
+
+    #! temp workaround for runtime error
+    @validator("version", pre=True)
+    def parse_version(cls, value):
+        return 1

--- a/app/config.py
+++ b/app/config.py
@@ -1,4 +1,4 @@
-from pydantic import BaseSettings, EmailStr, validator
+from pydantic import BaseSettings, EmailStr
 
 
 class Settings(BaseSettings):
@@ -48,8 +48,3 @@ class LogConfig(BaseSettings):
     loggers = {
         "hataraki-backend": {"handlers": ["default"], "level": LOG_LEVEL},
     }
-
-    #! temp workaround for runtime error
-    @validator("version", pre=True)
-    def parse_version(cls, value):
-        return 1

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+# get cmd line arg default to hataraki-backend-container if none
+CONTAINER_NAME=${1:-hataraki-backend-container}
 
-make install
-venv/bin/uvicorn app.server:app --port 8001
+# stop and remove old container
+docker stop $CONTAINER_NAME
+docker rm $CONTAINER_NAME
+docker build -t hataraki-backend .
+docker run -d --name $CONTAINER_NAME -p 8001:8001 --env-file .env hataraki-backend

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,10 +5,14 @@ boto3==1.24.92
 dnspython==2.2.1
 email-validator==1.3.0
 fastapi==0.85.1
+httptools==0.5.0
 httpx==0.23.0
 passlib==1.7.4
 python-dotenv==0.21.0
 python-jose==3.3.0
 python-multipart==0.0.5
+pyyaml==6.0
 websockets==10.3
 uvicorn==0.18.3
+uvloop==0.17.0
+watchfiles==0.18.0


### PR DESCRIPTION
## Changes in this PR

- [x] Bug fix
- [x] New feature
- [ ] Breaking change of an existing feature
- [x] Refactor/Performance enhancements

## Overview

- Mitigate runtime bug by standardising environment for production using docker containers
- Temp workaround for runtime validation error on ubuntu 22.04 running python 3.10.6
- Issue is not replicable on Mac (M1) running python 3.9.6