### PR TITLE
Switch to using slim docker img

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM python:3.9-slim
 
 WORKDIR /code
 


### PR DESCRIPTION
## Changes in this PR

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change of an existing feature
- [x] Refactor/Performance enhancements

## Overview

- Use `python3.9-slim` instead
